### PR TITLE
[CB-13] fix(account): allow accounts to have 0 balance.

### DIFF
--- a/src/schemas/accountSchema.ts
+++ b/src/schemas/accountSchema.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export const accountSchema = z.object({
   number: z.number().int().positive(),
-  balance: z.number().positive(),
+  balance: z.number().nonnegative(),
 });
 
 export const createAccountSchema = z.object({


### PR DESCRIPTION
Altera validação de criação de conta para permitir também o valor de saldo igual.

A correção anterior visava restringir o saldo da conta para não permitir valores negativos, 
mas acabou restringindo o valor de saldo de conta para valores possitivos acima de 0.

Resolves #23 

